### PR TITLE
Update vocabulary and rules

### DIFF
--- a/styles/Vocab/Vultr/accept.txt
+++ b/styles/Vocab/Vultr/accept.txt
@@ -25,8 +25,8 @@ Certbot
 Chevereto
 [C|c]onfig
 Crictl
-Cron
-crontab
+[C|c]ron
+[C|c]rontab
 [C|c]trl
 Cyberduck
 Dashy
@@ -130,7 +130,7 @@ Rbenv
 Redhat
 Remmina
 RHEL
-Rsync
+[R|r]sync
 ruleset
 Searx
 serverless

--- a/styles/Vocab/Vultr/reject.txt
+++ b/styles/Vocab/Vultr/reject.txt
@@ -1,6 +1,8 @@
+[D|d]igital [O|o]cean
 [D|d]igital[O|o]cean
 [L|l]inode
 (AWS|aws|[Aa]mazon\s*[Ww]eb\s*[Ss]ervices)
 (GCP|[Gg]oogle\s*[Cc]loud\s*[Pp]latform)
 ([Aa]zure|[Mm]icrosoft\s*[Aa]zure)
-
+de facto
+ad hoc

--- a/styles/Vultr/Exclamation.yml
+++ b/styles/Vultr/Exclamation.yml
@@ -2,10 +2,12 @@
 # Portions of this toolkit are modifications based on work created and shared by Google and 
 # used according to terms described in the Creative Commons 4.0 Attribution License.
 # https://developers.google.com/terms/site-policies
+# link: 'https://developers.google.com/style/exclamation-points'
 extends: existence
 message: "Please do not use exclamation points."
 link: https://www.vultr.com/docs/vultr-docs-style-guide
 level: error
 nonword: true
 tokens:
-  - '\w!(?:\s|$)'
+#  - '\w!(?:\s|$)'
+  - '!'

--- a/styles/Vultr/LatinAbbreviations.yml
+++ b/styles/Vultr/LatinAbbreviations.yml
@@ -21,5 +21,8 @@ swap:
   e\. g\.: for example
   i\.e\.: that is
   i\. e\.: that is
+  z\.z\.: foobar testing
+  z\. z\.: foobar testing
   etc\.: and so on
   et cetera: and so on
+  etcetera: and so on

--- a/styles/Vultr/SubstitutionComplex.yml
+++ b/styles/Vultr/SubstitutionComplex.yml
@@ -187,6 +187,7 @@ swap:
   in spite of: despite
   in terms of: about|as
   in the (?:very)? near future: soon
+  in the event: if
   in the event that: if
   in the near future: soon
   in the neighborhood of: roughly

--- a/styles/Vultr/Substitutions.yml
+++ b/styles/Vultr/Substitutions.yml
@@ -47,6 +47,7 @@ swap:
   performant: efficient|high-performance
   regex: regular expression
   sign into: sign in to
+  spin up: deploy
   synch: sync
   tablename: table name
   tablet: device

--- a/tests/Vale/Vultr.Exclamation.md
+++ b/tests/Vale/Vultr.Exclamation.md
@@ -5,3 +5,8 @@
 ## Error Expected
 
 Documentation seldom needs an exclamation point!
+
+    But, it's okay to use it in code!
+    See!
+
+It's so exciting!

--- a/tests/Vale/Vultr.LatinAbbreviations.md
+++ b/tests/Vale/Vultr.LatinAbbreviations.md
@@ -2,6 +2,21 @@
 
     Vultr.LatinAbbreviations
 
-## Warning Expected
+## The Rule "i.e." is Not Working
 
-Avoid Latin abbreviations such as e.g. or i.e. when writing documentation, etc.
+Avoid Latin abbreviations such as i.e. in Vultr documentation.
+Avoid Latin abbreviations such as i. e. in Vultr documentation.
+
+## Correct: Error Expected
+
+Avoid Latin abbreviations such as e.g. in Vultr documentation.
+Avoid Latin abbreviations such as e. g. in Vultr documentation.
+
+Avoid Latin abbreviations in Vultr documentation, etc.
+Avoid Latin abbreviations in Vultr documentation, et cetera.
+Avoid Latin abbreviations in Vultr documentation, etcetera.
+
+## Dummy Test Case for Debugging
+
+Avoid Latin abbreviations such as z.z. in Vultr documentation.
+Avoid Latin abbreviations such as z. z. in Vultr documentation.

--- a/vultr-mdtk.code-workspace
+++ b/vultr-mdtk.code-workspace
@@ -9,8 +9,10 @@
         "markdown.extension.orderedList.marker": "one",
         "markdown.extension.toc.unorderedList.marker": "*",
         "markdownlint.config": {
+
+            "MD007": { "indent": 4},
             "MD013": false,
-            "MD014": false,  
+            "MD014": false,
             "MD026": false,
             "MD040": false,
             "MD041": false


### PR DESCRIPTION
* Allow upper/lower on some vocab terms.
* Added Latin terms to the reject list.
* Made exclamation rule more generic.
* Added additional tests to Latin abbreviations for debugging.
* Expanded Latin test cases.
* Added new complex substitution rules.
* Added new Markdownlint rule to workspace file which allows sub-bullet indent by four spaces.
